### PR TITLE
2d to 3d improvements

### DIFF
--- a/GUI/src/cz/fidentis/gui/actions/importfromimage/Bundle.properties
+++ b/GUI/src/cz/fidentis/gui/actions/importfromimage/Bundle.properties
@@ -13,3 +13,4 @@ ImportFromImageDialog.panel_primarySecondary.border.title=Add as
 ImportFromImageDialog.title=Import Face from Image
 ImportFromImageDialog.jLabel2.text=Age of person
 ImportFromImageDialog.jLabel3.text=Gender of person
+ImportFromImageDialog.but_saveFp.text=Save Feature Points

--- a/GUI/src/cz/fidentis/gui/actions/importfromimage/Bundle.properties
+++ b/GUI/src/cz/fidentis/gui/actions/importfromimage/Bundle.properties
@@ -14,3 +14,5 @@ ImportFromImageDialog.title=Import Face from Image
 ImportFromImageDialog.jLabel2.text=Age of person
 ImportFromImageDialog.jLabel3.text=Gender of person
 ImportFromImageDialog.but_saveFp.text=Save Feature Points
+ImportFromImageDialog.projectLandmarksCheckbox.text=
+ImportFromImageDialog.projectLandmarksLabel.text=Project landmarks

--- a/GUI/src/cz/fidentis/gui/actions/importfromimage/ImageFpCanvas.java
+++ b/GUI/src/cz/fidentis/gui/actions/importfromimage/ImageFpCanvas.java
@@ -69,7 +69,7 @@ public class ImageFpCanvas extends JPanel {
     public void setPoints(List<FacialPoint> pts) {
         this.points = pts;
         for(FacialPoint p : points) {
-            p.getPosition().y = image.getHeight()-p.getPosition().y;
+            //p.getPosition().y = image.getHeight()-p.getPosition().y;
             constrainPoint(p.getPosition());
         }
         this.repaint();
@@ -82,21 +82,10 @@ public class ImageFpCanvas extends JPanel {
             image = origI;
             currentX = 0; currentY = 0; currentW = image.getWidth();
             this.repaint();
-            //offsetY = (this.getHeight() - this.getIcon().getIconHeight()) / 2;
-            //offsetX = (this.getWidth() - this.getIcon().getIconWidth()) / 2;
         } catch (IOException ex) {
             JOptionPane.showMessageDialog(null, "Could not open image.");
         }
     }
-    
-    /*@Override
-    public void addPropertyChangeListener(String propertyName, PropertyChangeListener listener) {
-        if(propertyName.equals(FP_PROPERTY_NAME)) {
-            this._listener = listener;
-        } else {
-            super.addPropertyChangeListener(propertyName, listener);
-        }
-    }*/
 
     @Override
     public void paint(Graphics g) {
@@ -152,7 +141,6 @@ public class ImageFpCanvas extends JPanel {
     
     private int computeHeight() {
         if(image != null) {
-            //return (int)(currentW / (image.getWidth()/((double)image.getHeight())));
             float aspect = this.getHeight() / (float) this.getWidth();
             return (int)(aspect*currentW);
         } else {
@@ -187,21 +175,6 @@ public class ImageFpCanvas extends JPanel {
         float yr = ((float)y) / this.getHeight();
         return new Vector3f(currentX + currentW*xr, currentY + computeHeight()*yr, 0);
     }
-    
-    /*private Vector3f pointToCoords(Vector3f point) {
-        if(this.getIcon() == null) {
-            return new Vector3f();
-        }
-        double x = (point.x / origWidth) * this.getIcon().getIconWidth();
-        double y = ((origHeight - point.y) / origHeight) * this.getIcon().getIconHeight();
-        return new Vector3f((float)x + offsetX, (float)y + offsetY, 0);
-    }
-    
-    private Vector3f coordsToPoint(int x, int y) {
-        double px = ((double)(x - offsetX) / this.getIcon().getIconWidth()) * origWidth;
-        double py = (1-((double)(y - offsetY) / this.getIcon().getIconHeight())) * origHeight;
-        return new Vector3f((float)px, (float)py, 0);
-    }*/
     
     private void constrainView() {
         if(image == null) return;

--- a/GUI/src/cz/fidentis/gui/actions/importfromimage/ImportFromImageDialog.form
+++ b/GUI/src/cz/fidentis/gui/actions/importfromimage/ImportFromImageDialog.form
@@ -10,7 +10,7 @@
       <ResourceString bundle="cz/fidentis/gui/actions/Bundle.properties" key="ImportFromImageDialog.title" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
     </Property>
     <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
-      <Dimension value="[512, 260]"/>
+      <Dimension value="[512, 300]"/>
     </Property>
     <Property name="modal" type="boolean" value="true"/>
   </Properties>
@@ -48,7 +48,7 @@
               <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
                   <Component id="jPanel1" max="32767" attributes="0"/>
-                  <Component id="canvas" pref="310" max="32767" attributes="0"/>
+                  <Component id="canvas" pref="378" max="32767" attributes="0"/>
               </Group>
               <EmptySpace max="-2" attributes="0"/>
           </Group>
@@ -74,23 +74,30 @@
               <Component id="but_browse" alignment="1" max="32767" attributes="0"/>
               <Component id="panel_primarySecondary" alignment="1" max="32767" attributes="0"/>
               <Group type="102" alignment="1" attributes="0">
-                  <EmptySpace max="-2" attributes="0"/>
-                  <Group type="103" groupAlignment="0" attributes="0">
-                      <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
-                      <Component id="jLabel2" alignment="0" min="-2" max="-2" attributes="0"/>
-                      <Component id="jLabel3" alignment="0" min="-2" max="-2" attributes="0"/>
-                  </Group>
-                  <EmptySpace pref="24" max="32767" attributes="0"/>
-                  <Group type="103" groupAlignment="0" max="-2" attributes="0">
-                      <Component id="ageComboBox" alignment="1" max="32767" attributes="0"/>
-                      <Component id="numOfVertsSpinner" alignment="1" pref="95" max="32767" attributes="0"/>
-                      <Component id="genderSelect" max="32767" attributes="0"/>
-                  </Group>
-              </Group>
-              <Group type="102" alignment="1" attributes="0">
                   <Component id="but_cancel" min="-2" max="-2" attributes="0"/>
                   <EmptySpace max="32767" attributes="0"/>
                   <Component id="but_ok" min="-2" max="-2" attributes="0"/>
+              </Group>
+              <Component id="but_saveFp" alignment="1" max="32767" attributes="0"/>
+              <Group type="102" attributes="0">
+                  <EmptySpace max="-2" attributes="0"/>
+                  <Group type="103" groupAlignment="0" attributes="0">
+                      <Group type="102" alignment="0" attributes="0">
+                          <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
+                          <EmptySpace pref="24" max="32767" attributes="0"/>
+                          <Component id="numOfVertsSpinner" min="-2" pref="95" max="-2" attributes="0"/>
+                      </Group>
+                      <Group type="102" alignment="0" attributes="0">
+                          <Component id="jLabel2" min="-2" max="-2" attributes="0"/>
+                          <EmptySpace max="32767" attributes="0"/>
+                          <Component id="ageComboBox" min="-2" pref="95" max="-2" attributes="0"/>
+                      </Group>
+                      <Group type="102" alignment="0" attributes="0">
+                          <Component id="jLabel3" min="-2" max="-2" attributes="0"/>
+                          <EmptySpace max="32767" attributes="0"/>
+                          <Component id="genderSelect" min="-2" pref="95" max="-2" attributes="0"/>
+                      </Group>
+                  </Group>
               </Group>
           </Group>
         </DimensionLayout>
@@ -101,21 +108,23 @@
                   <EmptySpace max="-2" attributes="0"/>
                   <Component id="but_loadFp" min="-2" max="-2" attributes="0"/>
                   <EmptySpace max="-2" attributes="0"/>
-                  <Component id="panel_primarySecondary" min="-2" max="-2" attributes="0"/>
+                  <Component id="but_saveFp" min="-2" max="-2" attributes="0"/>
                   <EmptySpace max="-2" attributes="0"/>
+                  <Component id="panel_primarySecondary" min="-2" max="-2" attributes="0"/>
+                  <EmptySpace type="unrelated" max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="3" attributes="0">
-                      <Component id="numOfVertsSpinner" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="jLabel1" alignment="3" min="-2" max="-2" attributes="0"/>
+                      <Component id="numOfVertsSpinner" alignment="3" min="-2" max="-2" attributes="0"/>
                   </Group>
                   <EmptySpace type="unrelated" max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="3" attributes="0">
-                      <Component id="ageComboBox" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="jLabel2" alignment="3" min="-2" max="-2" attributes="0"/>
+                      <Component id="ageComboBox" alignment="3" min="-2" max="-2" attributes="0"/>
                   </Group>
                   <EmptySpace type="unrelated" max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="3" attributes="0">
-                      <Component id="genderSelect" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="jLabel3" alignment="3" min="-2" max="-2" attributes="0"/>
+                      <Component id="genderSelect" alignment="3" min="-2" max="-2" attributes="0"/>
                   </Group>
                   <EmptySpace max="32767" attributes="0"/>
                   <Group type="103" groupAlignment="3" attributes="0">
@@ -179,7 +188,7 @@
                           <Component id="radio_primary" alignment="3" min="-2" max="-2" attributes="0"/>
                           <Component id="radio_secondary" alignment="3" min="-2" max="-2" attributes="0"/>
                       </Group>
-                      <EmptySpace max="-2" attributes="0"/>
+                      <EmptySpace max="32767" attributes="0"/>
                   </Group>
               </Group>
             </DimensionLayout>
@@ -275,6 +284,17 @@
           </Properties>
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="but_cancelActionPerformed"/>
+          </Events>
+        </Component>
+        <Component class="javax.swing.JButton" name="but_saveFp">
+          <Properties>
+            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+              <ResourceString bundle="cz/fidentis/gui/actions/importfromimage/Bundle.properties" key="ImportFromImageDialog.but_saveFp.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+            </Property>
+            <Property name="enabled" type="boolean" value="false"/>
+          </Properties>
+          <Events>
+            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="but_saveFpActionPerformed"/>
           </Events>
         </Component>
       </SubComponents>

--- a/GUI/src/cz/fidentis/gui/actions/importfromimage/ImportFromImageDialog.form
+++ b/GUI/src/cz/fidentis/gui/actions/importfromimage/ImportFromImageDialog.form
@@ -92,10 +92,16 @@
                           <EmptySpace max="32767" attributes="0"/>
                           <Component id="ageComboBox" min="-2" pref="95" max="-2" attributes="0"/>
                       </Group>
-                      <Group type="102" alignment="0" attributes="0">
-                          <Component id="jLabel3" min="-2" max="-2" attributes="0"/>
+                      <Group type="102" alignment="1" attributes="0">
+                          <Group type="103" groupAlignment="0" attributes="0">
+                              <Component id="jLabel3" min="-2" max="-2" attributes="0"/>
+                              <Component id="projectLandmarksLabel" alignment="0" min="-2" max="-2" attributes="0"/>
+                          </Group>
                           <EmptySpace max="32767" attributes="0"/>
-                          <Component id="genderSelect" min="-2" pref="95" max="-2" attributes="0"/>
+                          <Group type="103" groupAlignment="0" attributes="0">
+                              <Component id="projectLandmarksCheckbox" min="-2" max="-2" attributes="0"/>
+                              <Component id="genderSelect" min="-2" pref="95" max="-2" attributes="0"/>
+                          </Group>
                       </Group>
                   </Group>
               </Group>
@@ -125,6 +131,11 @@
                   <Group type="103" groupAlignment="3" attributes="0">
                       <Component id="jLabel3" alignment="3" min="-2" max="-2" attributes="0"/>
                       <Component id="genderSelect" alignment="3" min="-2" max="-2" attributes="0"/>
+                  </Group>
+                  <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                  <Group type="103" groupAlignment="0" attributes="0">
+                      <Component id="projectLandmarksCheckbox" min="-2" max="-2" attributes="0"/>
+                      <Component id="projectLandmarksLabel" min="-2" max="-2" attributes="0"/>
                   </Group>
                   <EmptySpace max="32767" attributes="0"/>
                   <Group type="103" groupAlignment="3" attributes="0">
@@ -296,6 +307,20 @@
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="but_saveFpActionPerformed"/>
           </Events>
+        </Component>
+        <Component class="javax.swing.JCheckBox" name="projectLandmarksCheckbox">
+          <Properties>
+            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+              <ResourceString bundle="cz/fidentis/gui/actions/importfromimage/Bundle.properties" key="ImportFromImageDialog.projectLandmarksCheckbox.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+            </Property>
+          </Properties>
+        </Component>
+        <Component class="javax.swing.JLabel" name="projectLandmarksLabel">
+          <Properties>
+            <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+              <ResourceString bundle="cz/fidentis/gui/actions/importfromimage/Bundle.properties" key="ImportFromImageDialog.projectLandmarksLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+            </Property>
+          </Properties>
         </Component>
       </SubComponents>
     </Container>

--- a/GUI/src/cz/fidentis/gui/actions/importfromimage/ImportFromImageDialog.java
+++ b/GUI/src/cz/fidentis/gui/actions/importfromimage/ImportFromImageDialog.java
@@ -81,6 +81,7 @@ public class ImportFromImageDialog extends javax.swing.JDialog implements Proper
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
         but_ok.setEnabled(featurePoints.size() >= 3);
+        but_saveFp.setEnabled(featurePoints.size() > 0);
     }
 
     /**
@@ -108,9 +109,10 @@ public class ImportFromImageDialog extends javax.swing.JDialog implements Proper
         jLabel3 = new javax.swing.JLabel();
         but_ok = new javax.swing.JButton();
         but_cancel = new javax.swing.JButton();
+        but_saveFp = new javax.swing.JButton();
 
         setTitle(org.openide.util.NbBundle.getMessage(ImportFromImageDialog.class, "ImportFromImageDialog.title")); // NOI18N
-        setMinimumSize(new java.awt.Dimension(512, 260));
+        setMinimumSize(new java.awt.Dimension(512, 300));
         setModal(true);
 
         canvas.setBorder(javax.swing.BorderFactory.createEtchedBorder());
@@ -157,7 +159,7 @@ public class ImportFromImageDialog extends javax.swing.JDialog implements Proper
                 .addGroup(panel_primarySecondaryLayout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(radio_primary)
                     .addComponent(radio_secondary))
-                .addContainerGap())
+                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
 
         numOfVertsSpinner.setModel(new javax.swing.SpinnerNumberModel(1000, 0, 10000, 1));
@@ -187,6 +189,14 @@ public class ImportFromImageDialog extends javax.swing.JDialog implements Proper
             }
         });
 
+        org.openide.awt.Mnemonics.setLocalizedText(but_saveFp, org.openide.util.NbBundle.getMessage(ImportFromImageDialog.class, "ImportFromImageDialog.but_saveFp.text")); // NOI18N
+        but_saveFp.setEnabled(false);
+        but_saveFp.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                but_saveFpActionPerformed(evt);
+            }
+        });
+
         javax.swing.GroupLayout jPanel1Layout = new javax.swing.GroupLayout(jPanel1);
         jPanel1.setLayout(jPanel1Layout);
         jPanel1Layout.setHorizontalGroup(
@@ -195,20 +205,25 @@ public class ImportFromImageDialog extends javax.swing.JDialog implements Proper
             .addComponent(but_browse, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
             .addComponent(panel_primarySecondary, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
             .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel1Layout.createSequentialGroup()
-                .addContainerGap()
-                .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(jLabel1)
-                    .addComponent(jLabel2)
-                    .addComponent(jLabel3))
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 24, Short.MAX_VALUE)
-                .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
-                    .addComponent(ageComboBox, javax.swing.GroupLayout.Alignment.TRAILING, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .addComponent(numOfVertsSpinner, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, 95, Short.MAX_VALUE)
-                    .addComponent(genderSelect, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)))
-            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel1Layout.createSequentialGroup()
                 .addComponent(but_cancel)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                 .addComponent(but_ok))
+            .addComponent(but_saveFp, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+            .addGroup(jPanel1Layout.createSequentialGroup()
+                .addContainerGap()
+                .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addGroup(jPanel1Layout.createSequentialGroup()
+                        .addComponent(jLabel1)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 24, Short.MAX_VALUE)
+                        .addComponent(numOfVertsSpinner, javax.swing.GroupLayout.PREFERRED_SIZE, 95, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addGroup(jPanel1Layout.createSequentialGroup()
+                        .addComponent(jLabel2)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addComponent(ageComboBox, javax.swing.GroupLayout.PREFERRED_SIZE, 95, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addGroup(jPanel1Layout.createSequentialGroup()
+                        .addComponent(jLabel3)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addComponent(genderSelect, javax.swing.GroupLayout.PREFERRED_SIZE, 95, javax.swing.GroupLayout.PREFERRED_SIZE))))
         );
         jPanel1Layout.setVerticalGroup(
             jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -217,19 +232,21 @@ public class ImportFromImageDialog extends javax.swing.JDialog implements Proper
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addComponent(but_loadFp)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addComponent(panel_primarySecondary, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addComponent(but_saveFp)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(numOfVertsSpinner, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(jLabel1))
+                .addComponent(panel_primarySecondary, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(ageComboBox, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(jLabel2))
+                    .addComponent(jLabel1)
+                    .addComponent(numOfVertsSpinner, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(genderSelect, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(jLabel3))
+                    .addComponent(jLabel2)
+                    .addComponent(ageComboBox, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel3)
+                    .addComponent(genderSelect, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                 .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(but_ok)
@@ -253,7 +270,7 @@ public class ImportFromImageDialog extends javax.swing.JDialog implements Proper
                 .addContainerGap()
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(jPanel1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .addComponent(canvas, javax.swing.GroupLayout.DEFAULT_SIZE, 310, Short.MAX_VALUE))
+                    .addComponent(canvas, javax.swing.GroupLayout.DEFAULT_SIZE, 378, Short.MAX_VALUE))
                 .addContainerGap())
         );
 
@@ -283,9 +300,9 @@ public class ImportFromImageDialog extends javax.swing.JDialog implements Proper
 
     private void but_loadFpActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_but_loadFpActionPerformed
         //despite list this will always be just one file
-        List<FpModel> loadedFp = FPImportExport.instance().importPoints(tc, false);
-        if(loadedFp == null)
-            return;
+        List<FpModel> loadedFp = FPImportExport.instance().importPoints(this, false);
+        if(loadedFp == null) return;
+        featurePoints.clear();
         featurePoints.addAll(loadedFp.get(0).getFacialPoints());
         
         canvas.setPoints(featurePoints);
@@ -301,6 +318,16 @@ public class ImportFromImageDialog extends javax.swing.JDialog implements Proper
         this.setVisible(false);
     }//GEN-LAST:event_but_okActionPerformed
 
+    private void but_saveFpActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_but_saveFpActionPerformed
+        ArrayList<FpModel> exportList = new ArrayList<>(featurePoints.size());
+        String modelName = "points";
+        if(imageFile != null) {
+            modelName = imageFile.getName();
+        }
+        exportList.add(FPImportExport.instance().getFpModelFromFP(featurePoints, modelName));
+        FPImportExport.instance().exportPoints(this, exportList);
+    }//GEN-LAST:event_but_saveFpActionPerformed
+
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JComboBox<AgeCategories> ageComboBox;
@@ -308,6 +335,7 @@ public class ImportFromImageDialog extends javax.swing.JDialog implements Proper
     private javax.swing.JButton but_cancel;
     private javax.swing.JButton but_loadFp;
     private javax.swing.JButton but_ok;
+    private javax.swing.JButton but_saveFp;
     private javax.swing.ButtonGroup buttonGroup1;
     private cz.fidentis.gui.actions.importfromimage.ImageFpCanvas canvas;
     private javax.swing.JComboBox<Gender> genderSelect;

--- a/GUI/src/cz/fidentis/gui/actions/importfromimage/ImportFromImageDialog.java
+++ b/GUI/src/cz/fidentis/gui/actions/importfromimage/ImportFromImageDialog.java
@@ -77,6 +77,10 @@ public class ImportFromImageDialog extends javax.swing.JDialog implements Proper
     public boolean isCanceled() {
         return this.canceled;
     }
+    
+    public boolean projectLandmarks(){
+        return projectLandmarksCheckbox.isSelected();
+    }
 
     @Override
     public void propertyChange(PropertyChangeEvent evt) {
@@ -110,6 +114,8 @@ public class ImportFromImageDialog extends javax.swing.JDialog implements Proper
         but_ok = new javax.swing.JButton();
         but_cancel = new javax.swing.JButton();
         but_saveFp = new javax.swing.JButton();
+        projectLandmarksCheckbox = new javax.swing.JCheckBox();
+        projectLandmarksLabel = new javax.swing.JLabel();
 
         setTitle(org.openide.util.NbBundle.getMessage(ImportFromImageDialog.class, "ImportFromImageDialog.title")); // NOI18N
         setMinimumSize(new java.awt.Dimension(512, 300));
@@ -197,6 +203,10 @@ public class ImportFromImageDialog extends javax.swing.JDialog implements Proper
             }
         });
 
+        org.openide.awt.Mnemonics.setLocalizedText(projectLandmarksCheckbox, org.openide.util.NbBundle.getMessage(ImportFromImageDialog.class, "ImportFromImageDialog.projectLandmarksCheckbox.text")); // NOI18N
+
+        org.openide.awt.Mnemonics.setLocalizedText(projectLandmarksLabel, org.openide.util.NbBundle.getMessage(ImportFromImageDialog.class, "ImportFromImageDialog.projectLandmarksLabel.text")); // NOI18N
+
         javax.swing.GroupLayout jPanel1Layout = new javax.swing.GroupLayout(jPanel1);
         jPanel1.setLayout(jPanel1Layout);
         jPanel1Layout.setHorizontalGroup(
@@ -220,10 +230,14 @@ public class ImportFromImageDialog extends javax.swing.JDialog implements Proper
                         .addComponent(jLabel2)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                         .addComponent(ageComboBox, javax.swing.GroupLayout.PREFERRED_SIZE, 95, javax.swing.GroupLayout.PREFERRED_SIZE))
-                    .addGroup(jPanel1Layout.createSequentialGroup()
-                        .addComponent(jLabel3)
+                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, jPanel1Layout.createSequentialGroup()
+                        .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addComponent(jLabel3)
+                            .addComponent(projectLandmarksLabel))
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                        .addComponent(genderSelect, javax.swing.GroupLayout.PREFERRED_SIZE, 95, javax.swing.GroupLayout.PREFERRED_SIZE))))
+                        .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addComponent(projectLandmarksCheckbox)
+                            .addComponent(genderSelect, javax.swing.GroupLayout.PREFERRED_SIZE, 95, javax.swing.GroupLayout.PREFERRED_SIZE)))))
         );
         jPanel1Layout.setVerticalGroup(
             jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -247,6 +261,10 @@ public class ImportFromImageDialog extends javax.swing.JDialog implements Proper
                 .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jLabel3)
                     .addComponent(genderSelect, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(projectLandmarksCheckbox)
+                    .addComponent(projectLandmarksLabel))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                 .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(but_ok)
@@ -345,6 +363,8 @@ public class ImportFromImageDialog extends javax.swing.JDialog implements Proper
     private javax.swing.JPanel jPanel1;
     private javax.swing.JSpinner numOfVertsSpinner;
     private javax.swing.JPanel panel_primarySecondary;
+    private javax.swing.JCheckBox projectLandmarksCheckbox;
+    private javax.swing.JLabel projectLandmarksLabel;
     private javax.swing.JRadioButton radio_primary;
     private javax.swing.JRadioButton radio_secondary;
     // End of variables declaration//GEN-END:variables


### PR DESCRIPTION
- added button to export 2d feature points
- changed the size of import from image dialog a bit
- import from image dialog now uses only our supported formats for facial point import/export
- NOTE: removed flipping the Y coordinate of feature points from canvas (present there before because of the FIDO csv format used flipped Y coords)