### PR TITLE
Size of landmarks when scaling was used during registration

### DIFF
--- a/GUI/src/cz/fidentis/gui/comparison_batch/BatchComparisonConfiguration.java
+++ b/GUI/src/cz/fidentis/gui/comparison_batch/BatchComparisonConfiguration.java
@@ -443,11 +443,13 @@ public class BatchComparisonConfiguration extends javax.swing.JPanel {
         //get correct value for selected avg model
         c.setTemplateIndex(c.getTemplateIndex() + 3);
         
-        c.setState(1);
-        GUIController.getConfigurationTopComponent().addBatchRegistrationComponent();
-       
         Model m = ModelLoader.instance().loadModel(getContext().getModel(0), false, true);
         GUIController.getSelectedProjectTopComponent().getViewerPanel_Batch().setModel(m);
+        GUIController.getSelectedProjectTopComponent().getViewerPanel_Batch().getListener().getFacialPoints().clear();
+        c.getFacialPoints().clear();
+        
+        c.setState(1);
+        GUIController.getConfigurationTopComponent().addBatchRegistrationComponent();  
     }//GEN-LAST:event_jButton1ActionPerformed
 
     private void jButton2ActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jButton2ActionPerformed

--- a/GUI/src/cz/fidentis/gui/comparison_batch/BatchRegistrationConfiguration.java
+++ b/GUI/src/cz/fidentis/gui/comparison_batch/BatchRegistrationConfiguration.java
@@ -1110,15 +1110,7 @@ public class BatchRegistrationConfiguration extends javax.swing.JPanel {
                         }
 
                         c.setRegistrationResults(results);
-                        
-                        if (c.isFpScaling()) {
-                            //tc.getViewerPanel_Batch().getListener().setCameraPosition(0, 0, 7);
-                            tc.getViewerPanel_Batch().getListener().setFacialPointRadius(c.getFpSize() / 30f);
-                        }
-                        /*else {
-                        tc.getViewerPanel_Batch().getListener().setCameraPosition(0, 0, 700);
-                       // tc.getViewerPanel_Batch().getListener().setFacialPointRadius(jSlider1.getValue());
-                    }*/
+                       
                         
                     }else{
                         noRegistration();
@@ -1420,15 +1412,11 @@ public class BatchRegistrationConfiguration extends javax.swing.JPanel {
             exportFpButton.setEnabled(true);
         }
         
-        //populateFacesComboBox();
         
+        GUIController.getSelectedProjectTopComponent().getViewerPanel_Batch().getFpExportEnable().updateObservers();
         facesComboBox.setSelectedIndex(c.getTemplateIndex());
         continueComparisonCheckBox.setSelected(c.isContinueComparison());
-        
-       /* if(c.getModels().size() > 0)
-            facesComboBox.setSelectedIndex(c.getTemplateIndex() + 3);
-       */
-       
+
     }
     
     private BatchComparison getContext(){

--- a/GUI/src/cz/fidentis/gui/comparison_batch/ViewerPanel_Batch.java
+++ b/GUI/src/cz/fidentis/gui/comparison_batch/ViewerPanel_Batch.java
@@ -111,6 +111,10 @@ public class ViewerPanel_Batch extends javax.swing.JPanel {
     public void setFpExportEnable(ObservableMaster fpExportEnable) {
         this.fpExportEnable = fpExportEnable;
     }
+
+    public ObservableMaster getFpExportEnable() {
+        return fpExportEnable;
+    }
     
 
     public void setEditablePoints(boolean b) {

--- a/GUI/src/cz/fidentis/gui/comparison_one_to_many/OneToManyComparisonConfiguration.java
+++ b/GUI/src/cz/fidentis/gui/comparison_one_to_many/OneToManyComparisonConfiguration.java
@@ -476,9 +476,14 @@ public class OneToManyComparisonConfiguration extends javax.swing.JPanel {
         Model model = ModelLoader.instance().loadModel(GUIController.getSelectedProjectTopComponent().getOneToManyViewerPanel().getListener2().getModel().getFile(), false, true);
 
         GUIController.getSelectedProjectTopComponent().getOneToManyViewerPanel().getListener2().setModels(model);
+        GUIController.getSelectedProjectTopComponent().getOneToManyViewerPanel().getListener2().getFacialPoints().clear();
+        getContext().getFacialPoints().clear();
 
         model = ModelLoader.instance().loadModel(GUIController.getSelectedProjectTopComponent().getOneToManyViewerPanel().getListener1().getModel().getFile(), false, true);
         GUIController.getSelectedProjectTopComponent().getOneToManyViewerPanel().getListener1().setModels(model);
+        GUIController.getSelectedProjectTopComponent().getOneToManyViewerPanel().getListener1().getFacialPoints().clear();
+ 
+        
         getContext().setState(1);
         GUIController.getConfigurationTopComponent().addOneToManyRegistrationComponent();
     }//GEN-LAST:event_jButton1ActionPerformed

--- a/GUI/src/cz/fidentis/gui/comparison_one_to_many/OneToManyRegistrationConfiguration.java
+++ b/GUI/src/cz/fidentis/gui/comparison_one_to_many/OneToManyRegistrationConfiguration.java
@@ -1052,12 +1052,6 @@ public class OneToManyRegistrationConfiguration extends javax.swing.JPanel {
 
                         c.setRegisteredModels(r);
 
-                        if (c.isFpScaling()) {
-                            tc.getOneToManyViewerPanel().getListener1().setFacialPointRadius(c.getFpSize() / 30f);
-
-                            tc.getOneToManyViewerPanel().getListener2().setFacialPointRadius(c.getFpSize() / 30f);
-                        }
-
                         tc.getOneToManyViewerPanel().getListener2().setFacialPoints(
                                 tc.getProject().getSelectedOneToManyComparison().getFacialPoints(
                                         tc.getOneToManyViewerPanel().getListener2().getModel().getName()
@@ -1360,6 +1354,7 @@ public class OneToManyRegistrationConfiguration extends javax.swing.JPanel {
            radiusSlider.setValue(50);
        }
        
+       GUIController.getSelectedProjectTopComponent().getOneToManyViewerPanel().getFpExportEnable().updateObservers();
        continueComparisonCheckBox.setSelected(c.isContinueComparison());
         
         if ((c.getRegistrationMethod().ordinal() == 0 && !areFPCalculated(GUIController.getSelectedProjectTopComponent())) || (!areModelsLoaded(GUIController.getSelectedProjectTopComponent()))) {

--- a/GUI/src/cz/fidentis/gui/comparison_one_to_many/ViewerPanel_1toN.java
+++ b/GUI/src/cz/fidentis/gui/comparison_one_to_many/ViewerPanel_1toN.java
@@ -85,6 +85,10 @@ public class ViewerPanel_1toN extends javax.swing.JPanel {
     public void setFpExportEnable(ObservableMaster fpExportEnable) {
         this.fpExportEnable = fpExportEnable;
     }
+
+    public ObservableMaster getFpExportEnable() {
+        return fpExportEnable;
+    }
     
     
 


### PR DESCRIPTION
Fixed error with visualization of landmarks being too small if scaling in registration was set up. Fixed error when register button was enabled when edit registration criteria button was pressed (this caused error) in 1:N and N:N mode