### PR TITLE
small bugs

### DIFF
--- a/Controller/src/cz/fidentis/controller/BatchComparison.java
+++ b/Controller/src/cz/fidentis/controller/BatchComparison.java
@@ -418,6 +418,15 @@ public class BatchComparison {
 
     public void setAverageFace(Model averageFace) {
         this.averageFace = averageFace;
+        // add node_average if the average was not set before
+        if(this.averageFace != null && this.node_average == null) {
+            node_average = node.addChild(strings.getString("tree.node.averageModel"));
+        }
+        // remove the node_average if the averageFace was set to null
+        if(this.averageFace == null && this.node_average != null) {
+            this.node.removeChild(this.node.getChildren().indexOf(this.node_average));
+            node_average = null;
+        }
     }
     
 
@@ -565,11 +574,19 @@ public class BatchComparison {
     public void setState(int state) {
         this.state = state;
         if (state >= 3) {
+            // add node_result if the state includes results
             if (this.node_result == null) {
                 this.node_result = this.node.addChild(strings.getString("tree.node.results"));
             }
         } else if (this.node_result != null) {
+            // there are no results in states less than 3 - remove the node_result if present
             this.node.removeChild(this.node.getChildren().indexOf(this.node_result));
+            this.node_result = null;
+        }
+        // remove the node_average if the state is before computing of average
+        if (state < 2 && this.node_average != null) {
+            this.node.removeChild(this.node.getChildren().indexOf(this.node_average));
+            this.node_average = null;
         }
         
     }

--- a/GUI/nbproject/project.xml
+++ b/GUI/nbproject/project.xml
@@ -128,6 +128,33 @@
                     </run-dependency>
                 </dependency>
                 <dependency>
+                    <code-name-base>org.netbeans.bootstrap</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <implementation-version/>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.core</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>2</release-version>
+                        <implementation-version/>
+                    </run-dependency>
+                </dependency>
+                <dependency>
+                    <code-name-base>org.netbeans.core.startup</code-name-base>
+                    <build-prerequisite/>
+                    <compile-dependency/>
+                    <run-dependency>
+                        <release-version>1</release-version>
+                        <implementation-version/>
+                    </run-dependency>
+                </dependency>
+                <dependency>
                     <code-name-base>org.netbeans.modules.options.api</code-name-base>
                     <build-prerequisite/>
                     <compile-dependency/>

--- a/GUI/src/cz/fidentis/gui/Installer.java
+++ b/GUI/src/cz/fidentis/gui/Installer.java
@@ -72,6 +72,13 @@ public class Installer extends ModuleInstall {
          UIManager.put("text", new Color(0, 0, 0));}*/ catch (URISyntaxException | ClassNotFoundException | InstantiationException | IllegalAccessException | UnsupportedLookAndFeelException | ConcurrentModificationException ex) {
             Exceptions.printStackTrace(ex);
         }
+        
+        // delete the temp folder if it existed before the start of the program
+        try {
+            FileUtils.instance().createTMPfolder(true);
+        } catch (FileManipulationException ex) {
+            Exceptions.printStackTrace(ex);
+        }
 
     }
 

--- a/GUI/src/cz/fidentis/gui/Installer.java
+++ b/GUI/src/cz/fidentis/gui/Installer.java
@@ -5,24 +5,19 @@
 package cz.fidentis.gui;
 
 import cz.fidentis.controller.Controller;
-import static cz.fidentis.gui.GUIController.addProjectTopComponent;
 import cz.fidentis.utils.FileUtils;
 import cz.fidentis.utils.LoadLibraries;
 import cz.fidentis.utilsException.FileManipulationException;
 import cz.fidentis.validator.OSValidator;
-import java.awt.Color;
 import java.io.File;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
 import javax.swing.JOptionPane;
 import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
-import org.opencv.LoadOpenCV;
 import org.openide.modules.ModuleInstall;
 import org.openide.util.Exceptions;
-import org.openide.windows.TopComponent;
-import org.openide.windows.WindowManager;
+import org.netbeans.core.startup.Splash;
 
 public class Installer extends ModuleInstall {
 
@@ -74,6 +69,8 @@ public class Installer extends ModuleInstall {
         }
         
         // delete the temp folder if it existed before the start of the program
+        Splash s = Splash.getInstance();
+        s.print("Removing the old temporary directory.");
         try {
             FileUtils.instance().createTMPfolder(true);
         } catch (FileManipulationException ex) {

--- a/GUI/src/cz/fidentis/gui/NavigatorTopComponent.java
+++ b/GUI/src/cz/fidentis/gui/NavigatorTopComponent.java
@@ -406,15 +406,15 @@ public final class NavigatorTopComponent extends TopComponent {
                         // display facial points of corresponding model (by index)
                         listener.setFacialPoints(batchComparison.getFacialPoints(batchComparison.getModel(lastNodeIndex).getName()));
                     }
-                    if(previousNodeText.equals(strings.getString("tree.node.averageModel"))) {
-                        if(batchComparison.getAverageFace() == null) listener.setModels(batchComparison.getAverageFace());
-                        else listener.setModels(batchComparison.getAverageFace());
+                    if(path.getLastPathComponent().toString().equals(strings.getString("tree.node.averageModel"))) {
+                        listener.setModels(batchComparison.getAverageFace());
                     }
                     if(path.getLastPathComponent().toString().equals(strings.getString("tree.node.results"))) {
                         if(batchComparison.getComparisonMethod() == ComparisonMethod.PROCRUSTES) {
                             listener.setFacialPoints(batchComparison.getFacialPoints(batchComparison.getModel(0).getName()));
                             listener.setProcrustes(true);
                         } else {
+                            listener.setModels(batchComparison.getAverageFace());
                             listener.drawHD(true);
                         }
                     }

--- a/GUI/src/cz/fidentis/gui/StartingPanel.java
+++ b/GUI/src/cz/fidentis/gui/StartingPanel.java
@@ -8,25 +8,19 @@ package cz.fidentis.gui;
 import cz.fidentis.controller.Controller;
 import cz.fidentis.controller.Project;
 import cz.fidentis.gui.actions.ButtonHelper;
-import cz.fidentis.gui.observer.ObservableMaster;
-import cz.fidentis.gui.observer.ProgressHandleObserver;
 import cz.fidentis.utils.FileUtils;
 import cz.fidentis.utilsException.FileManipulationException;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import javax.swing.BorderFactory;
 import org.openide.util.Exceptions;
 import org.openide.util.NbBundle;
-import org.openide.windows.WindowManager;
 
 /**
  *
  * @author Katka
  */
 public class StartingPanel extends javax.swing.JPanel {
-    private static boolean triedDeleting = false;    
-    
     /**
      * Creates new form StartingPanel
      */
@@ -304,28 +298,7 @@ public class StartingPanel extends javax.swing.JPanel {
             Project project = new Project("Project " + dateFormat.format(date));
             project.setName("Project " + dateFormat.format(date));
             try {
-                if(!triedDeleting){
-                    triedDeleting = true;
-                    
-                    ObservableMaster master = new ObservableMaster();
-                    final ProgressHandleObserver obs = new ProgressHandleObserver("Deleting tmp files");
-                    master.addObserver(obs);
-                
-                    Runnable run = new Runnable() {
-                        @Override
-                        public void run() {
-                            obs.startHandle();
-                        }
-                    };
-                
-                    Thread t = new Thread(run);
-                    t.start();                    
-                
-                    project.setTempDirectory(FileUtils.instance()
-                        .createTMPmoduleFolder(String.valueOf(System.currentTimeMillis())));
-                
-                    master.updateObservers();
-                }
+                project.setTempDirectory(FileUtils.instance().createTMPmoduleFolder(String.valueOf(System.currentTimeMillis())));
             } catch (FileManipulationException ex) {
                 Exceptions.printStackTrace(ex);
             }

--- a/GUI/src/cz/fidentis/gui/actions/OpenProject.java
+++ b/GUI/src/cz/fidentis/gui/actions/OpenProject.java
@@ -283,8 +283,19 @@ public final class OpenProject implements ActionListener {
                 ntc.getOneToManyViewerPanel().getCanvas2().setImportLabelVisible(false);
             }
             if (loadedFps != null) {
-                FPImportExport.instance().alignPointsToModels(loadedFps, comparison1N.getModels());
+                List<File> allModelFiles = new ArrayList<>();
+                allModelFiles.addAll(comparison1N.getModels());
+                if (comparison1N.getPrimaryModel() != null) {
+                    allModelFiles.add(comparison1N.getPrimaryModel().getFile());
+                }
+                FPImportExport.instance().alignPointsToModels(loadedFps, allModelFiles);
                 for (FpModel model : loadedFps) {
+                    if (comparison1N.getPrimaryModel() != null
+                            && model.getModelName().equals(comparison1N.getPrimaryModel().getName())) {
+                        ntc.getOneToManyViewerPanel().getListener1().setFacialPoints(model.getFacialPoints());
+                        ntc.getOneToManyViewerPanel().getListener1().initFpUniverse(model.getFacialPoints());
+
+                    }
                     comparison1N.addFacialPoints(model.getModelName(), model.getFacialPoints());
                 }
             }
@@ -498,12 +509,6 @@ public final class OpenProject implements ActionListener {
             comparison.setContinueComparison(Boolean.parseBoolean(attr));
         }
         
-        attr = projectE.getAttribute("firstCreated");
-        if(attr != null && !attr.isEmpty()){
-            comparison.setFirstCreated(Boolean.parseBoolean(attr));
-        }
-        
-        
         attr = projectE.getAttribute("visualization");
         if(attr != null && !attr.isEmpty()){
             comparison.setVisualization(VisualizationType.valueOf(attr));
@@ -716,10 +721,6 @@ public final class OpenProject implements ActionListener {
         attr = projectE.getAttribute("continueComparison");
         if (attr != null && !attr.isEmpty()) {
             comparison.setContinueComparison(Boolean.parseBoolean(attr));
-        }
-        attr = projectE.getAttribute("firstCreated");
-        if (attr != null && !attr.isEmpty()) {
-            comparison.setFirstCreated(Boolean.parseBoolean(attr));
         }
         
         attr = projectE.getAttribute("visualization");
@@ -980,11 +981,6 @@ public final class OpenProject implements ActionListener {
         attr = projectE.getAttribute("continueComparison");
         if(attr != null && !attr.isEmpty()){
             comparison.setContinueComparison(Boolean.parseBoolean(attr));
-        }
-        
-        attr = projectE.getAttribute("firstCreated");
-        if(attr != null && !attr.isEmpty()){
-            comparison.setFirstCreated(Boolean.parseBoolean(attr));
         }
         
         attr = projectE.getAttribute("visualization");

--- a/GUI/src/cz/fidentis/gui/actions/SaveProject.java
+++ b/GUI/src/cz/fidentis/gui/actions/SaveProject.java
@@ -265,7 +265,6 @@ public final class SaveProject implements ActionListener {
 
         comparisonE.setAttribute("valuesTypeIndex", String.valueOf(comparison.getValuesTypeIndex()));
         comparisonE.setAttribute("continueComparison", String.valueOf(comparison.isContinueComparison()));
-        comparisonE.setAttribute("firstCreated", String.valueOf(comparison.isFirstCreated()));
 
         if (comparison.getTransparencyViz() != null) {
             appendTransparencyData(comparison.getTransparencyViz(), comparisonE);
@@ -371,7 +370,10 @@ public final class SaveProject implements ActionListener {
             ArrayList<FpModel> fps = new ArrayList<>(comparison.getFacialPoints().size());
             for (String name : comparison.getFacialPoints().keySet()) {
                 FpModel fpmodel = FPImportExport.instance().getFpModelFromFP(comparison.getFacialPoints(name), name);
-                fpmodel.decentralizeToFile(comparison.getModel(name));
+                File modelFile = comparison.getModel(name);
+                if(modelFile != null) {
+                    fpmodel.decentralizeToFile(comparison.getModel(name));
+                }
                 fps.add(fpmodel);
             }
             if (!fpFile.exists()) {
@@ -419,7 +421,6 @@ public final class SaveProject implements ActionListener {
 
         comparisonE.setAttribute("continueComparison", String.valueOf(comparison.isContinueComparison()));
 
-        comparisonE.setAttribute("firstCreated", String.valueOf(comparison.isFirstCreated()));
 
         if (comparison.getVisualization() != null) {
             comparisonE.setAttribute("visualization", String.valueOf(comparison.getVisualization().name()));
@@ -557,7 +558,6 @@ public final class SaveProject implements ActionListener {
 
         comparisonE.setAttribute("continueComparison", String.valueOf(comparison.isContinueComparison()));
 
-        comparisonE.setAttribute("firstCreated", String.valueOf(comparison.isFirstCreated()));
 
         if (comparison.getVisualization() != null) {
             comparisonE.setAttribute("visualization", String.valueOf(comparison.getVisualization().name()));

--- a/Utils/src/cz/fidentis/utils/FileUtils.java
+++ b/Utils/src/cz/fidentis/utils/FileUtils.java
@@ -46,7 +46,7 @@ public final class FileUtils {
 
     private FileUtils() {
         try {
-            createTMPfolder(true);
+            createTMPfolder(false);
         } catch (FileManipulationException ex) {
             Logger.getLogger(FileUtils.class.getName()).log(Level.SEVERE, null, ex);
         }


### PR DESCRIPTION
BatchComparison.java - returned the use of `node_average` to make it possible to show average face
NavigatorTopComponent.java - there was a bug in displaying the average face node anyways, so fixed its condition. Also, for the "result" node it always makes sure to display the average model, not the last model displayed
StartingPanel.java - removed unnecessary code that did nothing. Its original purpose (deleting the temporary files folder) is now replaced by this https://github.com/Fidentis/Analyst/blob/development/Utils/src/cz/fidentis/utils/FileUtils.java#L130-L133 Also, now the code makes sure to create a separate, unique temporary folder for each project created