### PR TITLE
models are now centered for crosscuts visualization if no 

### DIFF
--- a/GUI/src/cz/fidentis/gui/comparison_batch/BatchComparisonResults.java
+++ b/GUI/src/cz/fidentis/gui/comparison_batch/BatchComparisonResults.java
@@ -1895,7 +1895,13 @@ public class BatchComparisonResults extends javax.swing.JPanel {
                     models.add(c.getAverageFace());
                     List<File> md = c.getRegistrationResults().size() > 0 ? c.getRegistrationResults() : c.getModels();
                     for (int i = 0; i < md.size(); i++) {
-                        Model m = ModelLoader.instance().loadModel(md.get(i), false, false);
+                        Model m;
+                        
+                        if(c.getRegistrationMethod() == RegistrationMethod.NO_REGISTRATION)
+                            m = ModelLoader.instance().loadModel(md.get(i), false, true);
+                        else
+                            m = ModelLoader.instance().loadModel(md.get(i), false, false);
+                        
                         models.add(m);
                     }
                     tc.getViewerPanel_Batch().getListener2().setModels(models);

--- a/GUI/src/cz/fidentis/gui/comparison_one_to_many/OneToManyComparisonResults.java
+++ b/GUI/src/cz/fidentis/gui/comparison_one_to_many/OneToManyComparisonResults.java
@@ -1971,8 +1971,12 @@ public class OneToManyComparisonResults extends javax.swing.JPanel {
             models.add(c.getPrimaryModel());
 
             for (int i = 0; i < c.getRegisteredModels().size(); i++) {
-                //registered models will be null if ICP wasn't used
-                Model m = l.loadModel(c.getRegisteredModels().get(i), false, false);
+                Model m;
+                if(c.getRegistrationMethod() == RegistrationMethod.NO_REGISTRATION)
+                    m = l.loadModel(c.getRegisteredModels().get(i), false, true);
+                else
+                    m = l.loadModel(c.getRegisteredModels().get(i), false, false);
+                
                 models.add(m);
             }
             tc.getOneToManyViewerPanel().getListener2().setModels(models);


### PR DESCRIPTION
registration was performed, this should fix issue when pre-registered models didn't show properly registered in crosscuts. It's not certain whether this works in all cases